### PR TITLE
Improving app_server

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = app_server
-version = 0.6.0
+version = attr: app_server.__version__
 author = Andreas H. Kelch
 author_email = ak@mausbrand.de
 description = a lightweight web application launcher for gunicorn and static files.

--- a/src/app_server/__init__.py
+++ b/src/app_server/__init__.py
@@ -47,7 +47,7 @@ class WrappingApp(object):
 
 	def wsgi_app(self, environ, start_response):
 		request = Request(environ)
-		response = Response(f'Path not found or invalid: {request.path}', status=501)
+		response = Response(f'Path not found or invalid: {request.path}', status=404)
 		return response(environ, start_response)
 
 	def __call__(self, environ, start_response):
@@ -107,7 +107,7 @@ class mySharedData(SharedDataMiddleware):
 		for search_path, loader in self.exports:
 			#lets check for regex, and inject real_path
 			if re.match(search_path, path):
-				real_path = re.sub(search_path,r'{0}'.format(self.org_exports[search_path]),path)
+				real_path = re.sub(search_path, self.org_exports[search_path], path, 1)
 				real_filename, file_loader = self.get_file_loader(real_path)(None)
 
 				if file_loader is not None:

--- a/src/app_server/__init__.py
+++ b/src/app_server/__init__.py
@@ -9,6 +9,7 @@ from werkzeug.wsgi import get_path_info, wrap_file
 from werkzeug.utils import get_content_type
 from werkzeug.http import http_date, is_resource_modified
 
+__version__ = "0.6.1"
 
 applicationFolder = ""
 
@@ -230,6 +231,7 @@ def main():
 	ap.add_argument('--app_port', type=int, default=8090, help='internal gunicorn port')
 	ap.add_argument('--worker', type=int, default=1, help='amount of gunicorn workers')
 	ap.add_argument('--threads', type=int, default=5, help='amount of gunicorn threads')
+	ap.add_argument('-V', '--version', action='version', version='%(prog)s ' + __version__)
 
 	args = ap.parse_args()
 	print(args)


### PR DESCRIPTION
This may become v0.6.1 as it fixes a bug with static folders served without any regex-features.

It also changes the way how the version number is maintained, so it can be viewed on the command-line. You can change it just in the the `__init__.py`s `__version__` variable. 

More updates will follow soon, as I'm working on a clean-up of the entire code, as some functions are separated but only called once.