### PR TITLE
Misc doc tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@ But all [gunicorn](https://gunicorn.org/) projects can be started with it.
 The static paths are stored in an app.yaml as handlers and are therefore compatible to google appengine projects.
 
 ## Getting Started
-Take a look at the example folder. Here you can find a start.sh which starts the App Server on port 8081.
+Take a look at the example folder. Here you can find a start.sh which starts the App Server on port 8080.
+
+### External APIs
+App Server allows app code to connect to external APIs, eg [Google Cloud Datastore](https://cloud.google.com/datastore/docs/), like normal. To use the [local datastore emulator](https://cloud.google.com/datastore/docs/tools/datastore-emulator), first start it, then in a separate shell [set the appropriate environment variables](https://cloud.google.com/datastore/docs/tools/datastore-emulator#setting_environment_variables) (notably `DATASTORE_EMULATOR_HOST` and `DATASTORE_DATASET`) to point your app to it before you run App Server.
 
 ### Dependencies
 The app server dependents on the following packages

--- a/src/app_server/__init__.py
+++ b/src/app_server/__init__.py
@@ -196,8 +196,7 @@ def main():
 
     ap.add_argument("config_paths", metavar='yaml_path', nargs='+', help='Path to app.yaml file')
     ap.add_argument(
-        '-A', '--application', action='store', dest='app_id', required=True,
-        help='Set the application, overriding the application value from the app.yaml file.')
+        '-A', '--application', action='store', dest='app_id', required=True, help='Set the application id')
     ap.add_argument('--host', default="localhost", help='host name to which application modules should bind')
     ap.add_argument('--port', type=int, default=8080, help='port to which we bind the application')
     ap.add_argument('--gunicorn_port', type=int, default=8090, help='internal gunicorn port')


### PR DESCRIPTION
 Hi all! First off, thank you so much for making app-server. dev_appserver has been deprecated forever, and gradually degrading and rotting, but I've been putting off migrating away from it because I didn't want to maintain two different ways of serving static files, local vs prod. So glad I found this so I can keep them the same!

Here are a few minor tweaks I worked through as I got started:

* README: fix port (8080)
* Add instructions for using local datastore emulator
* Remove `--help` usage that says `--application` defaults to reading from `app.yaml`