### PR TITLE
Make version numbers of requirements fixed

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,12 +19,12 @@ package_dir =
 packages = find:
 python_requires = >=3.8
 install_requires =
-    werkzeug>=2.0.1
-    pyyaml>=5.4.1
-    gunicorn>=20.1.0
-    fs>=2.4.15
-    grpcio>=1.42.0
-    watchdog>=2.1.7
+    werkzeug=2.2.3
+    pyyaml=6.0
+    gunicorn=20.1.0
+    fs=2.4.16
+    grpcio=1.44.0
+    watchdog=2.2.1
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
This are the latest versions working and tested; watchdog==2.3.0 seems to have problems.
---
watchdog==2.3.0 produces a multi-threaded endless-loop printing these messages
```
 * Detected change in '/usr/lib/python3.10/importlib/machinery.py', reloading
 * Detected change in '/usr/lib/python3.10/importlib/_abc.py', reloading
 * Detected change in '/usr/lib/python3.10/posixpath.py', reloading
 * Detected change in '/usr/lib/python3.10/genericpath.py', reloading
 * Detected change in '/usr/lib/python3.10/_sitebuiltins.py', reloading
 * Detected change in '/usr/lib/python3.10/http/cookies.py', reloading
 * Detected change in '/usr/lib/python3.10/pickle.py', reloading
 * Detected change in '/usr/lib/python3.10/urllib/request.py', reloading
 * Detected change in '/usr/lib/python3.10/_compat_pickle.py', reloading
 * Detected change in '/usr/lib/python3.10/urllib/error.py', reloading
 * Detected change in '/usr/lib/python3.10/urllib/response.py', reloading
 * Detected change in '/usr/lib/python3.10/queue.py', reloading
 * Detected change in '/usr/lib/python3.10/functools.py', reloading
 * Detected change in '/usr/lib/python3.10/collections/__init__.py', reloading
 * Detected change in '/usr/lib/python3.10/encodings/idna.py', reloading
 * Detected change in '/usr/lib/python3.10/stringprep.py', reloading
 * Detected change in '/usr/lib/python3.10/zipfile.py', reloading
 * Detected change in '/usr/lib/python3.10/hashlib.py', reloading
 * Detected change in '/usr/lib/python3.10/pathlib.py', reloading
 * Detected change in '/usr/lib/python3.10/ntpath.py', reloading
 * Detected change in '/usr/lib/python3.10/typing.py', reloading
 * Detected change in '/usr/lib/python3.10/zoneinfo/__init__.py', reloading
 * Detected change in '/usr/lib/python3.10/zoneinfo/_tzpath.py', reloading
 * Detected change in '/usr/lib/python3.10/_sysconfigdata__linux_x86_64-linux-gnu.py', reloading
 * Detected change in '/usr/lib/python3.10/collections/abc.py', reloading
 * Detected change in '/usr/lib/python3.10/contextlib.py', reloading
 * Detected change in '/usr/lib/python3.10/zoneinfo/_common.py', reloading
 * Detected change in '/usr/lib/python3.10/urllib/request.py', reloading
 * Detected change in '/usr/lib/python3.10/re.py', reloading
```
It seems to be a bug in watchdog, which doesn't happen with version 2.2.1.
This pull request fixates the version numbers to avoid such problems in future.
Anyway, requirements must be updated manually from time to time.