### PR TITLE
feat: Support Subdomain.

### DIFF
--- a/src/app_server/__init__.py
+++ b/src/app_server/__init__.py
@@ -231,7 +231,7 @@ def start_server(host, port, gunicorn_port, appFolder, appYaml, timeout, protoco
     apps.update({"/": myProxy(app.wsgi_app, {
         "/": {
             "target": f"{protocol}://{host}:{gunicorn_port}/",
-            "host": f"{host}:{port}"
+            "host": None
         }
     },timeout=timeout)})
     app.wsgi_app = myDispatcher(app.wsgi_app, apps)


### PR DESCRIPTION
Currently the `HTTP_HOST` variable is always set to `localhost:8080` but if you set it to `None` now the request url will be taken and you can also call urls with a subdomain. Like `mustermann.localhost:8080`